### PR TITLE
Read gunziper version from manifest

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -996,8 +996,7 @@ public class BurpExtender implements IBurpExtender, IMessageEditorTabFactory,
 
         VariablesFunctions.init();
 
-        callbacks.setExtensionName("gunziper "
-                + Variables.getInstance().getVersionNumber());
+        callbacks.setExtensionName(Variables.getInstance().getExtensionName());
 
         callbacks.registerHttpListener(this);
 

--- a/src/main/java/variables/Variables.java
+++ b/src/main/java/variables/Variables.java
@@ -112,9 +112,8 @@ public class Variables implements Serializable {
     private String                               lastEnteredIntruderComparerSearchRegex                                                = Messages
                                                                                                                                                .getString("regex.based.search_regex.test");
     private String[]                             payloadListForIntruderCompare                                                         = null;
-    private final String                         versionNumber                                                                         = "0.9.8";
-    private final String                         ownLicenseString                                                                      = "#  gunziper "
-                                                                                                                                               + this.versionNumber
+    private final String                         ownLicenseString                                                                      = "#  "
+                                                                                                                                               + this.getExtensionName()
                                                                                                                                                + " for Burpsuite\n#\n#    Copyright (c) 2017, Frank Block <gunziper@f-block.org>\n#\n#    All rights reserved.\n#\n#  Redistribution and use in source and binary forms, with or without modification, \n#    are permitted provided that the following conditions are met:\n#\n#     * Redistributions of source code must retain the above copyright notice, this \n#     list of conditions and the following disclaimer.\n#   * Redistributions in binary form must reproduce the above copyright notice, \n#       this list of conditions and the following disclaimer in the documentation \n#       and/or other materials provided with the distribution.\n#     * The names of the contributors may not be used to endorse or promote products \n#         derived from this software without specific prior written permission.\n#\n#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" \n#   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE \n#   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE \n#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE \n#   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL \n#   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR \n#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER \n#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, \n#   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE \n#   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\n";
     private final String                         foreignLicenseString                                                                  = "google-diff-match-patch from http://code.google.com/p/google-diff-match-patch/\n\nDiff Match and Patch\n \n Copyright 2006 Google Inc.\n http://code.google.com/p/google-diff-match-patch\n \n Licensed under the Apache License, Version 2.0 (the \"License\");\n you may not use this file except in compliance with the License.\n You may obtain a copy of the License at\n \n http://www.apache.org/licenses/LICENSE-2.0\n \n Unless required by applicable law or agreed to in writing, software\n distributed under the License is distributed on an \"AS IS\" BASIS,\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n See the License for the specific language governing permissions and\n limitations under the License.\n";
     private final String                         foreignLicenseString2                                                                 = "java-diff-utils  from http://code.google.com/p/java-diff-utils/ \n\n   Copyright 2010 Dmitry Naumenko (dm.naumenko@gmail.com)\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n\nMyersDiff, written by Juanco Anez, licensed under the Apache Software License, Version 1.1";
@@ -710,9 +709,22 @@ public class Variables implements Serializable {
         return this.uniqueModeAmpersandSeparatedValuesForParameterExclusion;
     }
 
+    public String getExtensionName() {
+        String name = "gunziper";
+        Package pkg = getClass().getPackage();
+        if (pkg != null) {
+            name = pkg.getImplementationTitle();
+        }
+        return name + " " + getVersionNumber();
+    }
+    
     public String getVersionNumber() {
-
-        return this.versionNumber;
+        Package pkg = getClass().getPackage();
+        if (pkg == null) {
+            return "unknown";
+        } else {
+            return pkg.getImplementationVersion();
+        }
     }
 
     // /**


### PR DESCRIPTION
This PR refactors the version information. It is now loaded from the Manifest file of the JAR file which can be changed in in the build.gradle.