### PR TITLE
Included dependencies into jar 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'gunziper'
-version '0.9.8a'
+version '0.9.8b'
 
 apply plugin: 'java'
 
@@ -22,4 +22,5 @@ jar {
         attributes 'Implementation-Title': 'gunziper',
                    'Implementation-Version': version
     }
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }


### PR DESCRIPTION
The gComparer is broken in gradle build because oif missing dependencies. This pull request fixes this by including dependencies into the jar file during build.